### PR TITLE
fix: correct spacing in pricing section

### DIFF
--- a/index.html
+++ b/index.html
@@ -206,7 +206,7 @@
       <div class="grid">
         <div class="card"><div class="badge">Free</div><h3>Discovery Call</h3><p class="sub">Meet your coach, discuss goals & history, map next steps.</p><p style="font-weight:900; font-size:1.4rem">$0</p></div>
         <div class="card"><div class="badge">Womens Lifting Group</div><p class="sub">Learn to lift weights with like minded women.</p><p style="font-weight:900; font-size:1.4rem">8 sessions $699</p></div>
-        <div class="card"><div class="badge">Popular</div><h3>Personal Training</h3><ul class="sub"><li>Single: <strong>$110</strong></li><li>4sessions/month: <strong>$495/month</strong></li></ul></div>
+        <div class="card"><div class="badge">Popular</div><h3>Personal Training</h3><ul class="sub"><li>Single: <strong>$110</strong></li><li>4 sessions/month: <strong>$495/month</strong></li></ul></div>
         <div class="card"><div class="badge">Massage</div><h3>Massage Therapy</h3><ul class="sub"><li>Swedish Classic (60m): <strong>$100</strong></li><li>Sports Massage (60m): <strong>$110</strong></li></ul></div>
         <div class="card"><div class="badge">Best Value</div><h3>Train + Massage Bundle</h3><p class="sub">4 training + 2 massages/month.</p><p style="font-weight:900; font-size:1.4rem">$499/month</p></div>
       </div>


### PR DESCRIPTION
## Summary
- fix spacing issue in personal training pricing card

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68a21a7d4460832ebb4f1c180bb59c27