### PR TITLE
feat: update cta button color

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,8 +66,10 @@
       color:#fff; border:none; box-shadow:var(--shadow);
       transition:.2s ease;
     }
-    .cta.swedish{background:linear-gradient(135deg,var(--accent),var(--accent3));}
-    .cta.american{background:linear-gradient(135deg,var(--accent4),var(--accent2));}
+    .cta.swedish,
+    .cta.american{
+      background:linear-gradient(135deg,#ff7a00,#ffb347); /* Vibrant orange for strong CTA */
+    }
     .cta:hover{transform:translateY(-2px);opacity:.95}
 
     .outline{


### PR DESCRIPTION
## Summary
- use a vibrant orange gradient for all call-to-action buttons to maximize click-throughs

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a31aeab4f4832e8ad06bb0b93af615