### PR TITLE
Align pregnancy training page style with index

### DIFF
--- a/pregnancytraining.html
+++ b/pregnancytraining.html
@@ -1,215 +1,220 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8" />
+  <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Pregnancy Training — Strong Through Every Trimester</title>
-  <meta name="description" content="Safe, adaptable workouts for pregnancy and postpartum. Strong through every trimester.">
+  <meta name="description" content="Safe, adaptable workouts for pregnancy and postpartum. Strong through every trimester." />
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800;900&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
+
   <style>
     :root{
-      --bg:#0b0c10;
-      --ink:#e8ecef;
-      --muted:#a9b3bd;
-      --accent:#9AE6B4;
-      --accent-ink:#0b0c10;
-      --card:#12141a;
-      --stroke:#1f232b;
-      --link:#c7f0ff;
-      --focus:#7dd3fc;
-      --max:1100px;
-      --radius:16px;
-      --shadow:0 10px 30px rgba(0,0,0,.35);
+      --text:#000;
+      --muted:#333;
+      --accent:#005BAC;   /* Swedish Blue */
+      --accent2:#D62828;  /* American Red */
+      --accent3:#FFCC00;  /* Swedish Yellow */
+      --accent4:#3C3B6E;  /* American Blue */
+      --maxw:1200px;
+      --radius:18px;
+      --shadow:0 8px 20px rgba(0,0,0,.15);
+      --bgfade:0.7;
     }
+
     *{box-sizing:border-box}
-    html,body{margin:0;padding:0;background:var(--bg);color:var(--ink);font-family:'Inter',system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;line-height:1.5}
-    body{background-image:url('WEIGHTS AND STUFF STRENGTH & CONDITIONING.PNG');background-size:cover;background-repeat:no-repeat;background-position:center}
-    a{color:var(--link);text-decoration:none}
-    a:hover{text-decoration:underline}
-    .wrap{max-width:var(--max);margin-inline:auto;padding:24px}
-
-    /* Top bar */
-    .top{
-      display:flex;align-items:center;justify-content:space-between;gap:16px;
-      padding-block:10px;position:sticky;top:0;background:linear-gradient(180deg,rgba(11,12,16,.95),rgba(11,12,16,.75));backdrop-filter:saturate(1.4) blur(6px);z-index:10;border-bottom:1px solid var(--stroke)
+    html,body{margin:0;height:100%}
+    body{
+      font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial;
+      color: var(--text);
+      background:
+        linear-gradient(rgba(255,255,255,var(--bgfade)), rgba(255,255,255,var(--bgfade))),
+        url("WEIGHTS AND STUFF STRENGTH & CONDITIONING.PNG") no-repeat center center fixed;
+      background-size: cover;
+      line-height:1.55;
+      overflow-x:hidden;
+      text-align:center;
     }
-    .brand{font-weight:900;letter-spacing:.02em}
-    .brand span{opacity:.6;font-weight:700}
-    .nav{display:flex;gap:18px;flex-wrap:wrap}
-    .nav a{font-weight:600;opacity:.9}
 
-    /* Hero */
-    .hero{padding:72px 0 32px;display:grid;gap:18px}
-    .eyebrow{font-size:.95rem;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:var(--muted)}
-    h1{font-size:clamp(2rem,5vw,3.25rem);line-height:1.05;margin:0;font-weight:900}
-    .lead{font-size:1.125rem;color:var(--muted);max-width:65ch}
-    .cta-row{display:flex;gap:12px;flex-wrap:wrap;margin-top:8px}
-    .btn{display:inline-flex;align-items:center;justify-content:center;gap:10px;padding:14px 18px;border-radius:999px;border:1px solid var(--stroke);background:transparent;color:var(--ink);font-weight:700}
-    .btn.primary{background:var(--accent);color:var(--accent-ink);border-color:transparent}
-    .btn:hover{transform:translateY(-1px)}
+    a{color:var(--accent);text-decoration:none}
+    a:hover{opacity:.9}
 
-    /* Sections */
-    section{padding:24px 0;border-top:1px solid var(--stroke)}
-    h2{font-size:1.6rem;margin:0 0 10px}
-    .kicker{color:var(--muted);font-weight:600}
+    /* Header / Nav */
+    header{
+      position:sticky; top:0; z-index:40;
+      background:#fff;
+      border-bottom:1px solid #ddd;
+    }
+    .nav{
+      max-width:var(--maxw); margin:auto;
+      display:flex; align-items:center; justify-content:space-between;
+      gap:24px; padding:14px 22px;
+    }
+    .brand strong{
+      font-family:"Bebas Neue", system-ui; font-size:28px; line-height:1;
+    }
+    .navlinks{display:flex; gap:22px; flex-wrap:wrap; align-items:center}
+    .navlinks a{
+      color:var(--text); font-weight:700; text-transform:uppercase;
+    }
 
-    /* Feature grid */
-    .grid{display:grid;gap:16px;grid-template-columns:repeat(12,1fr)}
-    .col-4{grid-column:span 4}
-    .col-6{grid-column:span 6}
-    .col-12{grid-column:1/-1}
-    @media (max-width:900px){.col-4,.col-6{grid-column:1/-1}}
+    /* Buttons */
+    .cta{
+      padding:12px 18px; border-radius:12px; font-weight:900; text-transform:uppercase;
+      color:#fff; border:none; box-shadow:var(--shadow);
+      transition:.2s ease;
+    }
+    .cta.swedish,
+    .cta.american{
+      background: linear-gradient(135deg, var(--accent3), #ffd84d);
+    }
+    .cta:hover{transform:translateY(-2px);opacity:.95}
 
-    .card{background:var(--card);border:1px solid var(--stroke);border-radius:var(--radius);padding:22px;box-shadow:var(--shadow)}
-    .card h3{margin:0 0 6px;font-size:1.15rem}
-    .meta{color:var(--muted);font-weight:600}
+    /* Layout */
+    section{max-width:var(--maxw); margin:0 auto; padding:64px 22px}
+    h1,h2,h3{margin:0 0 10px; color:#000}
+    h1{font-family:"Bebas Neue"; font-size:clamp(46px,8vw,92px)}
+    h2{font-family:"Bebas Neue"; font-size:clamp(34px,5vw,52px)}
+    .sub{color:var(--muted); font-size:1.06rem}
+
+    .card{
+      background:#fff; color:#000;
+      border:1px solid #ddd; border-radius:var(--radius);
+      box-shadow:var(--shadow); padding:22px;
+      text-align:left;
+    }
+    .grid{display:grid; grid-template-columns:repeat(2,1fr); gap:18px}
+    @media (max-width:820px){.grid{grid-template-columns:1fr}}
 
     /* Form */
-    form{display:grid;gap:12px}
+    form{display:grid;gap:12px;margin-top:20px}
     .row{display:grid;gap:12px;grid-template-columns:1fr 1fr}
     @media (max-width:700px){.row{grid-template-columns:1fr}}
-    label{font-weight:700;font-size:.95rem}
-    input,select,textarea{width:100%;padding:14px 14px;border-radius:12px;border:1px solid var(--stroke);background:#0f1218;color:var(--ink);outline:none}
-    input:focus,select:focus,textarea:focus{border-color:var(--focus);box-shadow:0 0 0 3px rgba(125,211,252,.15)}
-    .help{color:var(--muted);font-size:.9rem}
-    .disclaimer{font-size:.85rem;color:var(--muted)}
-
-    /* Footer */
-    footer{padding:36px 0;color:var(--muted)}
-
-    /* Small badges */
-    .badge{display:inline-block;font-weight:800;letter-spacing:.06em;text-transform:uppercase;border:1px solid var(--stroke);padding:6px 10px;border-radius:999px;color:var(--muted)}
+    label{font-weight:700;font-size:.95rem;text-align:left;display:block}
+    input,select,textarea{width:100%;padding:14px;border-radius:12px;border:1px solid #ccc;background:#fff;color:var(--text);font-family:inherit;font-size:1rem}
+    input:focus,select:focus,textarea:focus{border-color:var(--accent);box-shadow:0 0 0 2px rgba(0,91,172,.2);outline:none}
+    .help{color:var(--muted);font-size:.9rem;text-align:left}
+    .disclaimer{font-size:.85rem;color:var(--muted);text-align:left}
   </style>
 </head>
 <body>
-  <header class="top wrap">
-    <div class="brand">PREGNANCY TRAINING <span>• Strong Through Every Trimester</span></div>
+  <header>
     <nav class="nav">
-      <a href="#program">Program</a>
-      <a href="#benefits">Benefits</a>
-      <a href="#signup">Sign up</a>
+      <a class="brand" href="index.html#top">
+        <div>
+          <strong>WEIGHTS AND STUFF</strong><br>
+          <span style="font-size:.78rem;color:var(--muted)">Strength &amp; Conditioning • Massage</span>
+        </div>
+      </a>
+      <div class="navlinks">
+        <a href="index.html#training">Training</a>
+        <a href="index.html#massage">Massage</a>
+        <a href="index.html#about">About</a>
+        <a href="index.html#pricing">Pricing</a>
+        <a href="index.html#calander" class="cta swedish">Book a free consultation now!</a>
+      </div>
     </nav>
   </header>
 
-  <main class="wrap">
-    <section class="hero" id="home">
-      <div class="eyebrow">Pregnancy & Postpartum</div>
+  <main id="top">
+    <!-- HERO -->
+    <section class="hero">
       <h1>Strong Through Every Trimester</h1>
-      <p class="lead">Safe, adaptable workouts for pregnancy and postpartum. Build capacity, confidence, and resilience—without guessing what’s safe.</p>
-      <div class="cta-row">
-        <a href="#signup" class="btn primary">Sign up for updates</a>
-        <a href="#program" class="btn">Explore the program</a>
+      <p class="sub">Safe, adaptable workouts for pregnancy and postpartum. Build capacity, confidence, and resilience—without guessing what’s safe.</p>
+      <div style="display:flex; gap:12px; flex-wrap:wrap; justify-content:center; margin-top:18px">
+        <a class="cta swedish" href="#signup">Sign up for updates</a>
+        <a class="cta american" href="#program">Explore the program</a>
       </div>
     </section>
 
+    <!-- PROGRAM -->
     <section id="program">
+      <h2>Program Overview</h2>
+      <p class="sub">Evidence-informed strength, mobility, and breath work.</p>
       <div class="grid">
-        <div class="col-6">
-          <div class="card">
-            <span class="badge">Program Overview</span>
-            <h2>Adaptable training that fits each trimester</h2>
-            <p class="kicker">Evidence-informed strength, mobility, and breath work.</p>
-            <ul>
-              <li>Trimester‑specific progressions and regressions</li>
-              <li>Pelvic floor & core‑friendly strategies</li>
-              <li>Clear coaching cues and video demos</li>
-              <li>Return‑to‑lifting roadmap for postpartum</li>
-            </ul>
-          </div>
-        </div>
-        <div class="col-6">
-          <div class="card">
-            <span class="badge">What you’ll need</span>
-            <h3>Minimal equipment. Maximum confidence.</h3>
-            <p class="meta">Dumbbells or kettlebells, a bench or sturdy chair, resistance bands.</p>
-            <p>Sessions are 30–45 minutes, 2–4 days per week, with options for low‑impact conditioning.</p>
-          </div>
-        </div>
+        <article class="card">
+          <h3>Adaptable training for each trimester</h3>
+          <ul class="sub" style="text-align:left">
+            <li>Trimester-specific progressions and regressions</li>
+            <li>Pelvic floor &amp; core-friendly strategies</li>
+            <li>Clear coaching cues and video demos</li>
+            <li>Return-to-lifting roadmap for postpartum</li>
+          </ul>
+        </article>
+        <article class="card">
+          <h3>Minimal equipment. Maximum confidence.</h3>
+          <p class="sub">Dumbbells or kettlebells, a bench or sturdy chair, resistance bands.</p>
+          <p class="sub">Sessions are 30–45 minutes, 2–4 days per week, with options for low-impact conditioning.</p>
+        </article>
       </div>
     </section>
 
+    <!-- BENEFITS -->
     <section id="benefits">
+      <h2>Benefits</h2>
       <div class="grid">
-        <div class="col-4"><div class="card"><h3>Train safely</h3><p class="meta">Guidelines that evolve with you—no fear‑mongering.</p></div></div>
-        <div class="col-4"><div class="card"><h3>Feel stronger</h3><p class="meta">Build strength and capacity with smart progressions.</p></div></div>
-        <div class="col-4"><div class="card"><h3>Recover better</h3><p class="meta">Postpartum pathway to return to lifting and life.</p></div></div>
+        <article class="card"><h3>Train safely</h3><p class="sub">Guidelines that evolve with you—no fear-mongering.</p></article>
+        <article class="card"><h3>Feel stronger</h3><p class="sub">Build strength and capacity with smart progressions.</p></article>
+        <article class="card"><h3>Recover better</h3><p class="sub">Postpartum pathway to return to lifting and life.</p></article>
       </div>
     </section>
 
+    <!-- SIGNUP -->
     <section id="signup">
-      <div class="grid">
-        <div class="col-6">
-          <div class="card">
-            <span class="badge">Get started</span>
-            <h2>Sign up for early access</h2>
-            <p class="kicker">Join the waitlist and get safe training tips in your inbox.</p>
-            <form name="signup" method="post" onsubmit="event.preventDefault(); handleSubmit(this)">
-              <div class="row">
-                <div>
-                  <label for="first">First name</label>
-                  <input id="first" name="first" autocomplete="given-name" required />
-                </div>
-                <div>
-                  <label for="last">Last name</label>
-                  <input id="last" name="last" autocomplete="family-name" />
-                </div>
-              </div>
-              <div>
-                <label for="email">Email</label>
-                <input id="email" name="email" type="email" autocomplete="email" required />
-              </div>
-              <div class="row">
-                <div>
-                  <label for="stage">Current stage</label>
-                  <select id="stage" name="stage">
-                    <option value="trying">Trying to conceive</option>
-                    <option value="t1">Trimester 1</option>
-                    <option value="t2">Trimester 2</option>
-                    <option value="t3">Trimester 3</option>
-                    <option value="postpartum">Postpartum</option>
-                  </select>
-                </div>
-                <div>
-                  <label for="goals">Primary goal</label>
-                  <select id="goals" name="goal">
-                    <option>Stay active</option>
-                    <option>Build strength</option>
-                    <option>Ease aches/pain</option>
-                    <option>Return to lifting</option>
-                  </select>
-                </div>
-              </div>
-              <div>
-                <label for="notes">Anything we should know?</label>
-                <textarea id="notes" name="notes" rows="3" placeholder="Optional"></textarea>
-                <p class="help">We’ll send 1–2 emails per month. No spam, ever.</p>
-              </div>
-              <button class="btn primary" type="submit">Join the waitlist</button>
-              <p class="disclaimer">By submitting, you agree to our <a href="#">privacy policy</a>.</p>
-            </form>
+      <h2>Sign up for early access</h2>
+      <p class="sub">Join the waitlist and get safe training tips in your inbox.</p>
+      <div class="card" style="max-width:700px;margin:auto;text-align:left">
+        <form name="signup" method="post" onsubmit="event.preventDefault(); handleSubmit(this)">
+          <div class="row">
+            <div>
+              <label for="first">First name</label>
+              <input id="first" name="first" autocomplete="given-name" required />
+            </div>
+            <div>
+              <label for="last">Last name</label>
+              <input id="last" name="last" autocomplete="family-name" />
+            </div>
           </div>
-        </div>
-        <div class="col-6">
-          <div class="card">
-            <h3>What happens next?</h3>
-            <ol>
-              <li>You’ll get a welcome email with quick-start guidance.</li>
-              <li>We’ll follow up with trimester‑specific tips and sample sessions.</li>
-              <li>When enrollment opens, you’ll have first access and early‑bird pricing.</li>
-            </ol>
+          <div>
+            <label for="email">Email</label>
+            <input id="email" name="email" type="email" autocomplete="email" required />
           </div>
-        </div>
+          <div class="row">
+            <div>
+              <label for="stage">Current stage</label>
+              <select id="stage" name="stage">
+                <option value="trying">Trying to conceive</option>
+                <option value="t1">Trimester 1</option>
+                <option value="t2">Trimester 2</option>
+                <option value="t3">Trimester 3</option>
+                <option value="postpartum">Postpartum</option>
+              </select>
+            </div>
+            <div>
+              <label for="goals">Primary goal</label>
+              <select id="goals" name="goal">
+                <option>Stay active</option>
+                <option>Build strength</option>
+                <option>Ease aches/pain</option>
+                <option>Return to lifting</option>
+              </select>
+            </div>
+          </div>
+          <div>
+            <label for="notes">Anything we should know?</label>
+            <textarea id="notes" name="notes" rows="3" placeholder="Optional"></textarea>
+            <p class="help">We’ll send 1–2 emails per month. No spam, ever.</p>
+          </div>
+          <button class="cta swedish" type="submit">Join the waitlist</button>
+          <p class="disclaimer">By submitting, you agree to our <a href="#">privacy policy</a>.</p>
+        </form>
       </div>
     </section>
-
-    <footer class="wrap">
-      <div>© <span id="yr"></span> Pregnancy Training — Strong Through Every Trimester</div>
-    </footer>
   </main>
 
   <script>
-    // Lightweight, form‑handler placeholder. Replace with your backend, Netlify, or Airtable later.
     function handleSubmit(form){
       const data = Object.fromEntries(new FormData(form).entries());
       console.log('Form submission', data);
@@ -220,7 +225,7 @@
       btn.disabled = true;
       setTimeout(()=>{btn.textContent = prev; btn.disabled = false;}, 3800);
     }
-    document.getElementById('yr').textContent = new Date().getFullYear();
   </script>
 </body>
 </html>
+


### PR DESCRIPTION
## Summary
- Restyled pregnancy training page to share color palette, typography, and layout with the homepage.
- Replaced dark theme with light, card-based sections and call-to-action buttons.
- Updated navigation to match the site's main header and links.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aabbbac064832eb345f45f33fa447a